### PR TITLE
Open opencode in new tmux split

### DIFF
--- a/after/plugin/keymaps.lua
+++ b/after/plugin/keymaps.lua
@@ -25,24 +25,36 @@ vim.keymap.set('v', 'K', ":m '<-2<CR>gv=gv", { silent = true, noremap = true })
 vim.keymap.set('n', 'Q', '<nop>', { noremap = true })
 vim.keymap.set('n', 'q:', '<nop>', { noremap = true })
 
--- open claude in tmux pane
+-- open opencode in tmux pane
 vim.keymap.set('n', '<leader><cr>', function()
-    -- check if a pane with claude title exists
+    -- check if a pane with opencode title exists
     local panes = vim.fn.system(
         'tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index} #{pane_title}"'
     )
-    local claude_pane = panes:match('([^%s]+)%s+claude%-ai')
+    local opencode_pane = panes:match('([^%s]+)%s+opencode')
 
-    if claude_pane then
-        -- switch to existing claude pane
-        vim.fn.system('tmux switch-client -t ' .. claude_pane)
-        vim.fn.system('tmux select-pane -t ' .. claude_pane)
+    if opencode_pane then
+        -- switch to existing opencode pane
+        vim.fn.system('tmux switch-client -t ' .. opencode_pane)
+        vim.fn.system('tmux select-pane -t ' .. opencode_pane)
     else
-        -- create new pane with claude and set title
-        vim.fn.system('tmux split-window -h -l 100 claude')
-        vim.fn.system('tmux select-pane -T "claude-ai"')
+        local command
+        for _, candidate in ipairs({ 'opencode', 'open-opencode', 'cursor open opencode' }) do
+            local executable = candidate:match('^([^%s]+)')
+            if executable and vim.fn.executable(executable) == 1 then
+                command = candidate
+                break
+            end
+        end
+        command = command or 'opencode'
+
+        -- create new pane with opencode and set title
+        vim.fn.system(
+            string.format('tmux split-window -h -l 100 %s', vim.fn.shellescape(command))
+        )
+        vim.fn.system('tmux select-pane -T "opencode"')
     end
-end, { noremap = true, silent = true, desc = 'Open Claude in tmux pane' })
+end, { noremap = true, silent = true, desc = 'Open OpenCode in tmux pane' })
 
 -- define keymaps when LSP is attached
 vim.api.nvim_create_autocmd('LspAttach', {


### PR DESCRIPTION
Retarget `<leader><CR>` to open `opencode` in a new tmux split or focus an existing `opencode` pane.

---
<a href="https://cursor.com/background-agent?bcId=bc-c166371a-32bc-4355-9a95-9065a54ac4b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c166371a-32bc-4355-9a95-9065a54ac4b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

