### PR TITLE
Update README and remove stylua config

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,9 +1,0 @@
-column_width = 100
-line_endings = "Unix"
-indent_type = "Spaces"
-indent_width = 4
-quote_style = "AutoPreferSingle"
-call_parentheses = "Always"
-
-[sort_requires]
-enabled = true

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ The following are required to use the configuration:
 - Neovim >= 0.11.0
 - A [nerd-font](https://github.com/ryanoasis/nerd-fonts) for glyphs.
 - [Pre-commit](https://pre-commit.com/) when editing the configuration.
+
+## Sample
+
+This is a sample line added to the README.


### PR DESCRIPTION
## Changes

- **Removed `.stylua.toml`**: Deleted the StyLua configuration file entirely
- **Updated `README.md`**: Added a new "Sample" section with placeholder content

## Notes

The removal of `.stylua.toml` means the project will now use StyLua's default formatting rules instead of the custom configuration that was previously defined (100 char line width, Unix line endings, 4-space indent, etc.).

The README update adds a new section, though the sample content appears to be placeholder text that may need to be replaced with actual documentation.